### PR TITLE
fruit spawn slider and persistant options

### DIFF
--- a/Scenes/UI/Options.gd
+++ b/Scenes/UI/Options.gd
@@ -1,5 +1,7 @@
 extends Control
 
+@onready var dropdown = $VBoxContainer/VBoxContainer/dropdown
+@onready var fruit_slider = $VBoxContainer/VBoxContainer/fruit_slider
 
 # Called when the node enters the scene tree for the first time.
 func _ready():


### PR DESCRIPTION
-options menu small visual update
-options menu fruit spawn slider
-options settings persist when u exit and them come back into it
-fruits despawn when walking over them to act as an easy pickup system
    -feels buggy when the way our interactions are setup
    - working on counter variable to increment fruits that have been picked up
