### PR TITLE
robie-48-options_and_spawns_update

### DIFF
--- a/DialogueManager/DialogueDatabase.gd
+++ b/DialogueManager/DialogueDatabase.gd
@@ -2,6 +2,20 @@
 extends Node
 
 var dialogues = []
+var apple = preload("res://Scenes/Objects/apple.tscn")
+var watermelon = preload("res://Scenes/Objects/watermelon.tscn")
+var banana = preload("res://Scenes/Objects/banana.tscn")
+
+###--- Rain state variable ---###
+# Rain states:
+	# 0 == No rain -- default
+	# 1 == Light rain
+	# 2 == Heavy rain
+	
+@export var rainState = 0
+@export var numOfFruits = 0
+@export var fruits = [apple, watermelon, banana]
+
 
 func _init():
 	var high_health = PlayerDialogue.new()
@@ -19,7 +33,23 @@ func _init():
 		"text": "Low Health",
 		})
 	dialogues.append(low_health)
-
+	
+	var no_rain = PlayerDialogue.new()
+	no_rain.set_data({
+		"id": "rain",
+		"conditions": {"rain": 0},
+		"text": "No Rain",
+	})
+	dialogues.append(no_rain)
+	
+	var light_rain = PlayerDialogue.new()
+	no_rain.set_data({
+		"id": "rain",
+		"conditions": {"rain": 1},
+		"text": "It is lightly raining",
+	})
+	dialogues.append(light_rain)
+	
 func get_dialogue_for_event(event_id: String, context: Dictionary) -> PlayerDialogue:
 	for dialogue in dialogues:
 		if dialogue.id == event_id:
@@ -31,3 +61,13 @@ func get_dialogue_for_event(event_id: String, context: Dictionary) -> PlayerDial
 			if conditions_met:
 				return dialogue
 	return null
+
+
+#getter for grabbing current rainstate
+func getRainState():
+	return rainState
+
+
+func getNumOfFruits():
+	return numOfFruits
+	

--- a/Scenes/Objects/apple.tscn
+++ b/Scenes/Objects/apple.tscn
@@ -1,19 +1,31 @@
-[gd_scene load_steps=4 format=3 uid="uid://bltkrbvu3qaf0"]
+[gd_scene load_steps=5 format=3 uid="uid://bltkrbvu3qaf0"]
 
 [ext_resource type="Texture2D" uid="uid://boe7m3gnsdjah" path="res://Assets/apple.png" id="1_c7j5r"]
+[ext_resource type="Script" path="res://Scenes/Objects/object_pickup.gd" id="1_qfnap"]
 [ext_resource type="PackedScene" uid="uid://wn2tfo2th3ss" path="res://Scenes/InteractArea.tscn" id="2_pe56a"]
 
-[sub_resource type="CircleShape2D" id="CircleShape2D_1b54a"]
+[sub_resource type="CircleShape2D" id="CircleShape2D_3b16d"]
 radius = 3.0
 
 [node name="StaticBody2D" type="StaticBody2D"]
+script = ExtResource("1_qfnap")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 scale = Vector2(0.375, 0.375)
 texture = ExtResource("1_c7j5r")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("CircleShape2D_1b54a")
-
 [node name="InteractArea" parent="." instance=ExtResource("2_pe56a")]
+scale = Vector2(0.760001, 0.68)
 interact_label = "Apple"
+
+[node name="PickupArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]
+shape = SubResource("CircleShape2D_3b16d")
+
+[connection signal="area_entered" from="InteractArea" to="." method="_on_interact_area_area_entered"]
+[connection signal="area_entered" from="InteractArea" to="InteractArea" method="_on_area_entered"]
+[connection signal="area_exited" from="InteractArea" to="InteractArea" method="_on_area_exited"]
+[connection signal="area_shape_entered" from="InteractArea" to="InteractArea" method="_on_area_shape_entered"]
+[connection signal="area_entered" from="PickupArea" to="." method="_on_pickup_area_area_entered"]
+[connection signal="area_entered" from="PickupArea" to="." method="_on_area_2d_area_entered"]

--- a/Scenes/Objects/banana.tscn
+++ b/Scenes/Objects/banana.tscn
@@ -1,21 +1,28 @@
-[gd_scene load_steps=4 format=3 uid="uid://r5nirb85gn1l"]
+[gd_scene load_steps=5 format=3 uid="uid://r5nirb85gn1l"]
 
 [ext_resource type="Texture2D" uid="uid://dl5tdamrkleyc" path="res://Assets/banana.png" id="1_evp1s"]
+[ext_resource type="Script" path="res://Scenes/Objects/object_pickup.gd" id="1_yi14f"]
 [ext_resource type="PackedScene" uid="uid://wn2tfo2th3ss" path="res://Scenes/InteractArea.tscn" id="2_uajx3"]
 
-[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_7ikm2"]
-height = 22.0
+[sub_resource type="CircleShape2D" id="CircleShape2D_jriil"]
+radius = 3.0
 
 [node name="StaticBody2D" type="StaticBody2D"]
+script = ExtResource("1_yi14f")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(0.375, 0.375)
 texture = ExtResource("1_evp1s")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-scale = Vector2(1.22864, 1.01013)
-shape = SubResource("CapsuleShape2D_7ikm2")
-
 [node name="InteractArea" parent="." instance=ExtResource("2_uajx3")]
-position = Vector2(-1, 0)
-scale = Vector2(1.89249, 1.67312)
-interact_label = "Bananana"
+scale = Vector2(-0.498291, 0.601061)
+interact_label = "Banana"
+
+[node name="PickupArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]
+shape = SubResource("CircleShape2D_jriil")
+
+[connection signal="area_entered" from="InteractArea" to="." method="_on_interact_area_area_entered"]
+[connection signal="area_entered" from="InteractArea" to="InteractArea" method="_on_area_entered"]
+[connection signal="area_entered" from="PickupArea" to="." method="_on_pickup_area_area_entered"]

--- a/Scenes/Objects/object_pickup.gd
+++ b/Scenes/Objects/object_pickup.gd
@@ -1,0 +1,28 @@
+extends StaticBody2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+#pickup item 
+func _on_pickup_area_area_entered(area):
+	queue_free()
+	
+	
+	#if (interactLabel.text == "apple"):
+	#		DialogueDatabase.appleCount += 1
+	#if (interactLabel.text == "watermelon"):
+	#		DialogueDatabase.watermelonCount += 1
+	#if (interactLabel.text == "banana"):
+	#DialogueDatabase.bananaCount += 1
+	#DialogueDatabase.fruitTotal += 1
+	#DialogueDatabase.fruitOutput()
+	
+	
+	

--- a/Scenes/Objects/watermelon.tscn
+++ b/Scenes/Objects/watermelon.tscn
@@ -1,26 +1,28 @@
-[gd_scene load_steps=4 format=3 uid="uid://bxan7ldn2c83d"]
+[gd_scene load_steps=5 format=3 uid="uid://bxan7ldn2c83d"]
 
 [ext_resource type="Texture2D" uid="uid://psnxjtlcduqy" path="res://Assets/watermelon.png" id="1_ivih8"]
-[ext_resource type="PackedScene" uid="uid://wn2tfo2th3ss" path="res://Scenes/Player/InteractArea.tscn" id="2_817wg"]
+[ext_resource type="Script" path="res://Scenes/Objects/object_pickup.gd" id="1_w55tp"]
+[ext_resource type="PackedScene" uid="uid://wn2tfo2th3ss" path="res://Scenes/InteractArea.tscn" id="2_817wg"]
 
-[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_f2g2x"]
-radius = 2.17213
-height = 7.16317
+[sub_resource type="CircleShape2D" id="CircleShape2D_h46da"]
+radius = 6.08276
 
 [node name="StaticBody2D" type="StaticBody2D"]
+script = ExtResource("1_w55tp")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(0, -1)
 scale = Vector2(0.375, 0.375)
 texture = ExtResource("1_ivih8")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(1, 0)
-rotation = -2.27416
-shape = SubResource("CapsuleShape2D_f2g2x")
-
 [node name="InteractArea" parent="." instance=ExtResource("2_817wg")]
 position = Vector2(1, 0)
 interact_label = "Watermelon"
-interact_type = "text"
-interact_value = "1"
+
+[node name="PickupArea" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="PickupArea"]
+shape = SubResource("CircleShape2D_h46da")
+
+[connection signal="area_entered" from="InteractArea" to="." method="_on_interact_area_area_entered"]
+[connection signal="area_entered" from="PickupArea" to="." method="_on_pickup_area_area_entered"]

--- a/Scenes/Player/player.gd
+++ b/Scenes/Player/player.gd
@@ -87,10 +87,6 @@ func update_interactions():
 		#grabs interct_label variable defined in each object
 		interactLabel.text = all_interactions[0].interact_label
 		
-		#increment interact_counter variable
-		all_interactions[0].interact_counter += 1
-		#debugging output
-		print(all_interactions[0].interact_counter)
 	else:
 		interactLabel.text = ""
 

--- a/Scenes/Tilemap/TileMap.gd
+++ b/Scenes/Tilemap/TileMap.gd
@@ -1,17 +1,20 @@
 extends TileMap
 
-var apple = preload("res://Scenes/Objects/apple.tscn")
-var watermelon = preload("res://Scenes/Objects/watermelon.tscn")
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	spawn(10)
+	var fruits = DialogueDatabase
+	print("NUMBER OF FRUITS SPAWNED IN THIS INSTANCE: ", fruits.getNumOfFruits())
+	spawn(fruits.getNumOfFruits())
+
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-# x = number of object instances to spawn
+# x = number of object instances to spaw
 func spawn(x):
 	while (x != 0):
 		randomize()
-		var fruits = [apple, watermelon]
+		var database = DialogueDatabase
+		var fruits = database.fruits
 		var kinds = fruits[randi()% fruits.size()]
 		var fruit = kinds.instantiate()
 		fruit.position = Vector2(randi_range(100,300), randi_range(-50, -150))

--- a/Scenes/UI/Opt2DB6.tmp
+++ b/Scenes/UI/Opt2DB6.tmp
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://c8avj8dg4andl"]
+[gd_scene load_steps=8 format=3 uid="uid://c8avj8dg4andl"]
 
 [ext_resource type="Script" path="res://Scenes/UI/Options.gd" id="1_goqlf"]
 [ext_resource type="Texture2D" uid="uid://dixct1ewdl6mv" path="res://Assets/background.jpg" id="1_h1tn8"]
+[ext_resource type="Texture2D" uid="uid://cycv3bhhqpyyo" path="res://icon.png" id="2_aavqo"]
 [ext_resource type="FontFile" uid="uid://dg5ck0bgmm7yp" path="res://Assets/PixelifySans-Regular.ttf" id="3_govfu"]
 
 [sub_resource type="Theme" id="Theme_uqqsp"]
@@ -29,17 +30,35 @@ script = ExtResource("1_goqlf")
 [node name="Backdrop" type="Sprite2D" parent="."]
 modulate = Color(0.105882, 0.117647, 0.113725, 1)
 position = Vector2(192, 104)
-scale = Vector2(0.164, 0.164)
+scale = Vector2(0.164208, 0.164207)
 texture = ExtResource("1_h1tn8")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
-offset_left = 96.0
-offset_top = -18.0
-offset_right = 480.0
-offset_bottom = 198.0
-scale = Vector2(0.86979, 1.06979)
+offset_right = 384.0
+offset_bottom = 216.0
 alignment = 1
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="BoxContainer" type="BoxContainer" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+alignment = 1
+
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/VBoxContainer2/BoxContainer"]
+custom_minimum_size = Vector2(50, 52)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = ExtResource("2_aavqo")
+expand_mode = 1
+
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("3_govfu")
+theme_override_font_sizes/font_size = 24
+text = "Godot Dynamic Dialog"
+horizontal_alignment = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
 custom_minimum_size = Vector2(200, 0)
@@ -50,7 +69,17 @@ theme_override_constants/separation = 10
 alignment = 1
 metadata/_edit_group_ = true
 
-[node name="dropdown" type="OptionButton" parent="VBoxContainer/VBoxContainer"]
+[node name="Back" type="Button" parent="VBoxContainer/VBoxContainer"]
+layout_mode = 2
+theme = SubResource("Theme_uqqsp")
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 10
+theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
+theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
+text = "Back
+"
+
+[node name="OptionButton" type="OptionButton" parent="VBoxContainer/VBoxContainer"]
 layout_mode = 2
 item_count = 3
 selected = 0
@@ -60,10 +89,6 @@ popup/item_1/text = "Light Rain"
 popup/item_1/id = 1
 popup/item_2/text = "Heavy Rain"
 popup/item_2/id = 2
-
-[node name="fruit_slider" type="HSlider" parent="VBoxContainer/VBoxContainer"]
-layout_mode = 2
-max_value = 50.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -84,43 +109,7 @@ theme_override_font_sizes/font_size = 8
 text = "Github"
 uri = "https://github.com/Godot-Dynamic-Dialog/GodotDynamicDialog"
 
-[node name="back" type="HBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 174.0
-offset_top = -1.0
-offset_right = 198.0
-offset_bottom = 20.0
-
-[node name="Back" type="Button" parent="back"]
-layout_mode = 2
-theme = SubResource("Theme_uqqsp")
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 10
-theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
-theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
-text = "Back
-"
-
-[node name="Rain Type" type="Label" parent="."]
-layout_mode = 0
-offset_left = 42.0
-offset_top = 68.0
-offset_right = 118.0
-offset_bottom = 94.0
-text = "Rain Type
-"
-
-[node name="Fruit Spawns" type="Label" parent="."]
-layout_mode = 0
-offset_left = 43.0
-offset_top = 102.0
-offset_right = 142.0
-offset_bottom = 128.0
-text = "Fruit spawns
-"
-
-[connection signal="item_focused" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_focused"]
-[connection signal="item_selected" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/VBoxContainer/fruit_slider" to="." method="_on_fruit_slider_value_changed"]
-[connection signal="pressed" from="back/Back" to="." method="_on_back_pressed"]
-[connection signal="pressed" from="back/Back" to="back/Back" method="_on_pressed" flags=18]
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="." method="_on_back_pressed"]
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="VBoxContainer/VBoxContainer/Back" method="_on_pressed" flags=18]
+[connection signal="item_focused" from="VBoxContainer/VBoxContainer/OptionButton" to="." method="_on_option_button_item_focused"]
+[connection signal="item_selected" from="VBoxContainer/VBoxContainer/OptionButton" to="." method="_on_option_button_item_selected"]

--- a/Scenes/UI/Opt345F.tmp
+++ b/Scenes/UI/Opt345F.tmp
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://c8avj8dg4andl"]
+[gd_scene load_steps=8 format=3 uid="uid://c8avj8dg4andl"]
 
 [ext_resource type="Script" path="res://Scenes/UI/Options.gd" id="1_goqlf"]
 [ext_resource type="Texture2D" uid="uid://dixct1ewdl6mv" path="res://Assets/background.jpg" id="1_h1tn8"]
+[ext_resource type="Texture2D" uid="uid://cycv3bhhqpyyo" path="res://icon.png" id="2_aavqo"]
 [ext_resource type="FontFile" uid="uid://dg5ck0bgmm7yp" path="res://Assets/PixelifySans-Regular.ttf" id="3_govfu"]
 
 [sub_resource type="Theme" id="Theme_uqqsp"]
@@ -29,17 +30,35 @@ script = ExtResource("1_goqlf")
 [node name="Backdrop" type="Sprite2D" parent="."]
 modulate = Color(0.105882, 0.117647, 0.113725, 1)
 position = Vector2(192, 104)
-scale = Vector2(0.164, 0.164)
+scale = Vector2(0.164208, 0.164207)
 texture = ExtResource("1_h1tn8")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
-offset_left = 96.0
-offset_top = -18.0
-offset_right = 480.0
-offset_bottom = 198.0
-scale = Vector2(0.86979, 1.06979)
+offset_right = 384.0
+offset_bottom = 216.0
 alignment = 1
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="BoxContainer" type="BoxContainer" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+alignment = 1
+
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/VBoxContainer2/BoxContainer"]
+custom_minimum_size = Vector2(50, 52)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = ExtResource("2_aavqo")
+expand_mode = 1
+
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("3_govfu")
+theme_override_font_sizes/font_size = 24
+text = "Godot Dynamic Dialog"
+horizontal_alignment = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
 custom_minimum_size = Vector2(200, 0)
@@ -49,6 +68,16 @@ size_flags_stretch_ratio = 1.23
 theme_override_constants/separation = 10
 alignment = 1
 metadata/_edit_group_ = true
+
+[node name="Back" type="Button" parent="VBoxContainer/VBoxContainer"]
+layout_mode = 2
+theme = SubResource("Theme_uqqsp")
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 10
+theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
+theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
+text = "Back
+"
 
 [node name="dropdown" type="OptionButton" parent="VBoxContainer/VBoxContainer"]
 layout_mode = 2
@@ -60,10 +89,6 @@ popup/item_1/text = "Light Rain"
 popup/item_1/id = 1
 popup/item_2/text = "Heavy Rain"
 popup/item_2/id = 2
-
-[node name="fruit_slider" type="HSlider" parent="VBoxContainer/VBoxContainer"]
-layout_mode = 2
-max_value = 50.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -84,43 +109,7 @@ theme_override_font_sizes/font_size = 8
 text = "Github"
 uri = "https://github.com/Godot-Dynamic-Dialog/GodotDynamicDialog"
 
-[node name="back" type="HBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 174.0
-offset_top = -1.0
-offset_right = 198.0
-offset_bottom = 20.0
-
-[node name="Back" type="Button" parent="back"]
-layout_mode = 2
-theme = SubResource("Theme_uqqsp")
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 10
-theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
-theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
-text = "Back
-"
-
-[node name="Rain Type" type="Label" parent="."]
-layout_mode = 0
-offset_left = 42.0
-offset_top = 68.0
-offset_right = 118.0
-offset_bottom = 94.0
-text = "Rain Type
-"
-
-[node name="Fruit Spawns" type="Label" parent="."]
-layout_mode = 0
-offset_left = 43.0
-offset_top = 102.0
-offset_right = 142.0
-offset_bottom = 128.0
-text = "Fruit spawns
-"
-
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="." method="_on_back_pressed"]
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="VBoxContainer/VBoxContainer/Back" method="_on_pressed" flags=18]
 [connection signal="item_focused" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_focused"]
 [connection signal="item_selected" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/VBoxContainer/fruit_slider" to="." method="_on_fruit_slider_value_changed"]
-[connection signal="pressed" from="back/Back" to="." method="_on_back_pressed"]
-[connection signal="pressed" from="back/Back" to="back/Back" method="_on_pressed" flags=18]

--- a/Scenes/UI/Opt83D.tmp
+++ b/Scenes/UI/Opt83D.tmp
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://c8avj8dg4andl"]
+[gd_scene load_steps=8 format=3 uid="uid://c8avj8dg4andl"]
 
 [ext_resource type="Script" path="res://Scenes/UI/Options.gd" id="1_goqlf"]
 [ext_resource type="Texture2D" uid="uid://dixct1ewdl6mv" path="res://Assets/background.jpg" id="1_h1tn8"]
+[ext_resource type="Texture2D" uid="uid://cycv3bhhqpyyo" path="res://icon.png" id="2_aavqo"]
 [ext_resource type="FontFile" uid="uid://dg5ck0bgmm7yp" path="res://Assets/PixelifySans-Regular.ttf" id="3_govfu"]
 
 [sub_resource type="Theme" id="Theme_uqqsp"]
@@ -29,17 +30,35 @@ script = ExtResource("1_goqlf")
 [node name="Backdrop" type="Sprite2D" parent="."]
 modulate = Color(0.105882, 0.117647, 0.113725, 1)
 position = Vector2(192, 104)
-scale = Vector2(0.164, 0.164)
+scale = Vector2(0.164208, 0.164207)
 texture = ExtResource("1_h1tn8")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
-offset_left = 96.0
-offset_top = -18.0
-offset_right = 480.0
-offset_bottom = 198.0
-scale = Vector2(0.86979, 1.06979)
+offset_right = 384.0
+offset_bottom = 216.0
 alignment = 1
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="BoxContainer" type="BoxContainer" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+alignment = 1
+
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/VBoxContainer2/BoxContainer"]
+custom_minimum_size = Vector2(50, 52)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = ExtResource("2_aavqo")
+expand_mode = 1
+
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("3_govfu")
+theme_override_font_sizes/font_size = 24
+text = "Godot Dynamic Dialog"
+horizontal_alignment = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
 custom_minimum_size = Vector2(200, 0)
@@ -50,7 +69,17 @@ theme_override_constants/separation = 10
 alignment = 1
 metadata/_edit_group_ = true
 
-[node name="dropdown" type="OptionButton" parent="VBoxContainer/VBoxContainer"]
+[node name="Back" type="Button" parent="VBoxContainer/VBoxContainer"]
+layout_mode = 2
+theme = SubResource("Theme_uqqsp")
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 10
+theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
+theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
+text = "Back
+"
+
+[node name="OptionButton" type="OptionButton" parent="VBoxContainer/VBoxContainer"]
 layout_mode = 2
 item_count = 3
 selected = 0
@@ -60,10 +89,6 @@ popup/item_1/text = "Light Rain"
 popup/item_1/id = 1
 popup/item_2/text = "Heavy Rain"
 popup/item_2/id = 2
-
-[node name="fruit_slider" type="HSlider" parent="VBoxContainer/VBoxContainer"]
-layout_mode = 2
-max_value = 50.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -84,43 +109,7 @@ theme_override_font_sizes/font_size = 8
 text = "Github"
 uri = "https://github.com/Godot-Dynamic-Dialog/GodotDynamicDialog"
 
-[node name="back" type="HBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 174.0
-offset_top = -1.0
-offset_right = 198.0
-offset_bottom = 20.0
-
-[node name="Back" type="Button" parent="back"]
-layout_mode = 2
-theme = SubResource("Theme_uqqsp")
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 10
-theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
-theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
-text = "Back
-"
-
-[node name="Rain Type" type="Label" parent="."]
-layout_mode = 0
-offset_left = 42.0
-offset_top = 68.0
-offset_right = 118.0
-offset_bottom = 94.0
-text = "Rain Type
-"
-
-[node name="Fruit Spawns" type="Label" parent="."]
-layout_mode = 0
-offset_left = 43.0
-offset_top = 102.0
-offset_right = 142.0
-offset_bottom = 128.0
-text = "Fruit spawns
-"
-
-[connection signal="item_focused" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_focused"]
-[connection signal="item_selected" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/VBoxContainer/fruit_slider" to="." method="_on_fruit_slider_value_changed"]
-[connection signal="pressed" from="back/Back" to="." method="_on_back_pressed"]
-[connection signal="pressed" from="back/Back" to="back/Back" method="_on_pressed" flags=18]
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="." method="_on_back_pressed"]
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="VBoxContainer/VBoxContainer/Back" method="_on_pressed" flags=18]
+[connection signal="item_focused" from="VBoxContainer/VBoxContainer/OptionButton" to="." method="_on_option_button_item_focused"]
+[connection signal="item_selected" from="VBoxContainer/VBoxContainer/OptionButton" to="." method="_on_option_button_item_selected"]

--- a/Scenes/UI/Opt8599.tmp
+++ b/Scenes/UI/Opt8599.tmp
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://c8avj8dg4andl"]
+[gd_scene load_steps=8 format=3 uid="uid://c8avj8dg4andl"]
 
 [ext_resource type="Script" path="res://Scenes/UI/Options.gd" id="1_goqlf"]
 [ext_resource type="Texture2D" uid="uid://dixct1ewdl6mv" path="res://Assets/background.jpg" id="1_h1tn8"]
+[ext_resource type="Texture2D" uid="uid://cycv3bhhqpyyo" path="res://icon.png" id="2_aavqo"]
 [ext_resource type="FontFile" uid="uid://dg5ck0bgmm7yp" path="res://Assets/PixelifySans-Regular.ttf" id="3_govfu"]
 
 [sub_resource type="Theme" id="Theme_uqqsp"]
@@ -29,17 +30,35 @@ script = ExtResource("1_goqlf")
 [node name="Backdrop" type="Sprite2D" parent="."]
 modulate = Color(0.105882, 0.117647, 0.113725, 1)
 position = Vector2(192, 104)
-scale = Vector2(0.164, 0.164)
+scale = Vector2(0.164208, 0.164207)
 texture = ExtResource("1_h1tn8")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0
-offset_left = 96.0
-offset_top = -18.0
-offset_right = 480.0
-offset_bottom = 198.0
-scale = Vector2(0.86979, 1.06979)
+offset_right = 384.0
+offset_bottom = 216.0
 alignment = 1
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="BoxContainer" type="BoxContainer" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+alignment = 1
+
+[node name="TextureRect" type="TextureRect" parent="VBoxContainer/VBoxContainer2/BoxContainer"]
+custom_minimum_size = Vector2(50, 52)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = ExtResource("2_aavqo")
+expand_mode = 1
+
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer2"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("3_govfu")
+theme_override_font_sizes/font_size = 24
+text = "Godot Dynamic Dialog"
+horizontal_alignment = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
 custom_minimum_size = Vector2(200, 0)
@@ -50,7 +69,17 @@ theme_override_constants/separation = 10
 alignment = 1
 metadata/_edit_group_ = true
 
-[node name="dropdown" type="OptionButton" parent="VBoxContainer/VBoxContainer"]
+[node name="Back" type="Button" parent="VBoxContainer/VBoxContainer"]
+layout_mode = 2
+theme = SubResource("Theme_uqqsp")
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 10
+theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
+theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
+text = "Back
+"
+
+[node name="OptionButton" type="OptionButton" parent="VBoxContainer/VBoxContainer"]
 layout_mode = 2
 item_count = 3
 selected = 0
@@ -60,10 +89,6 @@ popup/item_1/text = "Light Rain"
 popup/item_1/id = 1
 popup/item_2/text = "Heavy Rain"
 popup/item_2/id = 2
-
-[node name="fruit_slider" type="HSlider" parent="VBoxContainer/VBoxContainer"]
-layout_mode = 2
-max_value = 50.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -84,43 +109,7 @@ theme_override_font_sizes/font_size = 8
 text = "Github"
 uri = "https://github.com/Godot-Dynamic-Dialog/GodotDynamicDialog"
 
-[node name="back" type="HBoxContainer" parent="."]
-layout_mode = 0
-offset_left = 174.0
-offset_top = -1.0
-offset_right = 198.0
-offset_bottom = 20.0
-
-[node name="Back" type="Button" parent="back"]
-layout_mode = 2
-theme = SubResource("Theme_uqqsp")
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_font_sizes/font_size = 10
-theme_override_styles/normal = SubResource("StyleBoxFlat_63ed5")
-theme_override_styles/hover = SubResource("StyleBoxFlat_b73bd")
-text = "Back
-"
-
-[node name="Rain Type" type="Label" parent="."]
-layout_mode = 0
-offset_left = 42.0
-offset_top = 68.0
-offset_right = 118.0
-offset_bottom = 94.0
-text = "Rain Type
-"
-
-[node name="Fruit Spawns" type="Label" parent="."]
-layout_mode = 0
-offset_left = 43.0
-offset_top = 102.0
-offset_right = 142.0
-offset_bottom = 128.0
-text = "Fruit spawns
-"
-
-[connection signal="item_focused" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_focused"]
-[connection signal="item_selected" from="VBoxContainer/VBoxContainer/dropdown" to="." method="_on_option_button_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/VBoxContainer/fruit_slider" to="." method="_on_fruit_slider_value_changed"]
-[connection signal="pressed" from="back/Back" to="." method="_on_back_pressed"]
-[connection signal="pressed" from="back/Back" to="back/Back" method="_on_pressed" flags=18]
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="." method="_on_back_pressed"]
+[connection signal="pressed" from="VBoxContainer/VBoxContainer/Back" to="VBoxContainer/VBoxContainer/Back" method="_on_pressed" flags=18]
+[connection signal="item_focused" from="VBoxContainer/VBoxContainer/OptionButton" to="." method="_on_option_button_item_focused"]
+[connection signal="item_selected" from="VBoxContainer/VBoxContainer/OptionButton" to="." method="_on_option_button_item_selected"]

--- a/Scenes/UI/Options.gd
+++ b/Scenes/UI/Options.gd
@@ -1,11 +1,12 @@
 extends Control
 
-
+@onready var dropdown = $VBoxContainer/VBoxContainer/dropdown
+@onready var fruit_slider = $VBoxContainer/VBoxContainer/fruit_slider
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	var rain = get_node("/root/MainMenu")
-	print(rain.rainState)
-
+	var database = get_node("/root/DialogueDatabase")
+	dropdown.selected = database.rainState
+	fruit_slider.value = database.numOfFruits
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
@@ -17,5 +18,10 @@ func _on_back_pressed():
 	
 
 func _on_option_button_item_selected(index):
-	var rain = get_node("/root/MainMenu")
+	var rain = get_node("/root/DialogueDatabase")
 	rain.rainState = index
+
+
+func _on_fruit_slider_value_changed(value):
+	var fruits = get_node("/root/DialogueDatabase")
+	fruits.numOfFruits = value

--- a/Scenes/UI/mainMenu.gd
+++ b/Scenes/UI/mainMenu.gd
@@ -1,10 +1,6 @@
 extends Control
 
-@export var rainState = 0
-#rain states:
-	# 0 == No rain
-	# 1 == Light rain
-	# 2 == Heavy rain
+
 	
 	
 # Called when the node enters the scene tree for the first time.
@@ -15,9 +11,7 @@ func _ready():
 func _process(delta):
 	pass
 
-#getter for grabbing current rainstate
-func getRainState():
-	return rainState
+
 
 #PLAY BUTTON
 func _on_play_pressed():

--- a/Scenes/Weather/HeavyRain.gd
+++ b/Scenes/Weather/HeavyRain.gd
@@ -2,9 +2,8 @@ extends Node2D
 
 
 func _ready():
-	var rain_reference = get_node("/root/MainMenu")
+	var rain_reference = get_node("/root/DialogueDatabase")
 	var rainState = rain_reference.getRainState()
 	
-	print("Current rainstate: ", rainState)
 	if (rainState != 2):
 		hide()

--- a/Scenes/Weather/Rain.gd
+++ b/Scenes/Weather/Rain.gd
@@ -4,10 +4,9 @@ extends Node2D
 # Called when the node enters the scene tree for the first time.
 
 func _ready():
-	var rain_reference = get_node("/root/MainMenu")
+	var rain_reference = get_node("/root/DialogueDatabase")
 	var rainState = rain_reference.getRainState()
 	
-	print("Current rainstate: ", rainState)
 	if (rainState != 1):
 		hide()
 	

--- a/Scenes/main.tscn
+++ b/Scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://c4lhqu3mr88aq"]
+[gd_scene load_steps=17 format=3 uid="uid://c4lhqu3mr88aq"]
 
 [ext_resource type="Texture2D" uid="uid://rmyte122fvng" path="res://Assets/tiles.png" id="2_ih2nm"]
 [ext_resource type="PackedScene" uid="uid://culk7qt4b4ddq" path="res://Scenes/Player/player.tscn" id="2_smu4t"]
@@ -11,7 +11,6 @@
 [ext_resource type="PackedScene" uid="uid://boi6ofya8suhr" path="res://Scenes/Objects/cave_entrance.tscn" id="7_risp2"]
 [ext_resource type="PackedScene" uid="uid://bxx5taw2bblgt" path="res://Scenes/Mobs/Ghost/ghost.tscn" id="11_5kdk5"]
 [ext_resource type="PackedScene" uid="uid://d2stelkgoeaop" path="res://Scenes/Weather/Rain.tscn" id="13_p0a21"]
-[ext_resource type="PackedScene" uid="uid://r5nirb85gn1l" path="res://Scenes/Objects/banana.tscn" id="13_pn3s8"]
 [ext_resource type="Script" path="res://Scenes/Weather/Rain.gd" id="14_fouvh"]
 [ext_resource type="PackedScene" uid="uid://ddhe3kgfx53ce" path="res://Scenes/Weather/HeavyRain.tscn" id="15_nwwl1"]
 [ext_resource type="Script" path="res://Scenes/Weather/HeavyRain.gd" id="16_llvw4"]
@@ -435,10 +434,6 @@ position = Vector2(392, 40)
 
 [node name="Ghost" parent="." instance=ExtResource("11_5kdk5")]
 position = Vector2(384, 168)
-
-[node name="Banana" parent="." instance=ExtResource("13_pn3s8")]
-position = Vector2(259, 238)
-collision_mask = 4
 
 [node name="MainRain" parent="." instance=ExtResource("13_p0a21")]
 script = ExtResource("14_fouvh")

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,8 @@ DialogueDatabase="*res://DialogueManager/DialogueDatabase.gd"
 DialogueManager="*res://DialogueManager/DialogueManager.gd"
 Rain="*res://Scenes/Weather/Rain.gd"
 MainMenu="*res://Scenes/UI/mainMenu.gd"
+Apple="*res://Scenes/Objects/apple.tscn"
+Banana="*res://Scenes/Objects/banana.tscn"
 
 [display]
 


### PR DESCRIPTION
-Options menu small visual update
-Added fruit spawner slider to increase/decrease number of fruits spawning into instance
-Option menu selections persist when exiting and reopening option menu before launching
-Walking over fruits "picks up" the item (item just disappears from instance for ease)
    -working on adding increments to global variables to track which fruits have been picked up
    -running into issues with adding this increment
    -need to possibly refine the interactions as it seems glitchy
